### PR TITLE
FIX api usage

### DIFF
--- a/Network_training/CNN.py
+++ b/Network_training/CNN.py
@@ -61,7 +61,10 @@ cross_entropy = -tf.reduce_sum(y_ * tf.log(y_conv))
 train_step = tf.train.AdagradOptimizer(1e-4).minimize(cross_entropy)
 correct_prediction = tf.equal(tf.argmax(y_conv, 1), tf.argmax(y_, 1))
 accuracy = tf.reduce_mean(tf.cast(correct_prediction, "float"))
-sess.run(tf.global_variables_initializer())
+if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<12): ### For tf version < 0.12.0
+    sess.run(tf.initialize_all_variables())
+else: ### For tf version >= 0.12.0
+    sess.run(tf.global_variables_initializer())
 for i in range(20000):
     batch = data.next_batch(50)
     if i % 100 == 0:

--- a/Network_training/SNN.py
+++ b/Network_training/SNN.py
@@ -14,7 +14,11 @@ y_ = tf.placeholder("float", [None, 26])
 cross_entropy = -tf.reduce_sum(y_ * tf.log(y))
 train_step = tf.train.GradientDescentOptimizer(0.0001).minimize(cross_entropy)
 sess = tf.Session()
-init = tf.initialize_all_variables()
+if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<12): ### For tf version < 0.12.0
+    init = tf.initialize_all_variables()
+else: ### For tf version >= 0.12.0
+    init = tf.global_variables_initializer()
+
 # saver = tf.train.Saver()
 # saver.restore(sess, "D:\Code\Python\model.ckpt")
 sess.run(init)


### PR DESCRIPTION
Dear developers,

I found one deprecated usage of TensorFlow APIs in your code as shown below and fixed it for you.

`tf.initialize_all_variables` has been deprecated in tf v0.12.0 and it's better to replace it with `tf.global_variables_initializer` to get the benefit of new APIs.

I made a fix for you which can make your code be compatible on more versions of TensorFlow. 
Hope you could take my advice and look forward to your reply! 😃 